### PR TITLE
use gzip if zstd is not supported

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ nfpms:
     - mtr
     - curl
     - traceroute
-    - zstd
+    # - zstd
     - sshpass
     - rsync
     - git


### PR DESCRIPTION
use gzip if zstd is not supported, either `zstd` package is not installed or very old `tar` version does not have the `--zstd` option. 

also remove `zstd` from deb package dependencies. `zstd` is not available on very old systems.